### PR TITLE
button1などの名前を修正

### DIFF
--- a/ShoppingApplication/Controllers/HowToUseCalculationViewController.swift
+++ b/ShoppingApplication/Controllers/HowToUseCalculationViewController.swift
@@ -3,18 +3,18 @@ import UIKit
 
 final class HowToUseCalculationViewController: UIViewController {
     private enum ImageType {
-        case image1
-        case image2
-        case image3
-        case image4
-        case image5
+        case firstPageImage
+        case secondPageImage
+        case thirdPageImage
+        case fourthPageImage
+        case fifthPageImage
         var name: String {
             switch self {
-            case .image1: return "HowToUseCalculationImage1"
-            case .image2: return "HowToUseCalculationImage2"
-            case .image3: return "HowToUseCalculationImage3"
-            case .image4: return "HowToUseCalculationImage4"
-            case .image5: return "HowToUseCalculationImage5"
+            case .firstPageImage: return "HowToUseCalculationImage1"
+            case .secondPageImage: return "HowToUseCalculationImage2"
+            case .thirdPageImage: return "HowToUseCalculationImage3"
+            case .fourthPageImage: return "HowToUseCalculationImage4"
+            case .fifthPageImage: return "HowToUseCalculationImage5"
             }
         }
     }
@@ -72,11 +72,11 @@ final class HowToUseCalculationViewController: UIViewController {
         } else {
             imageHeight = height
         }
-        let imageView1 = setImage(x: width*0, y: 0, width: width, height: imageHeight, imageType: .image1)
-        let imageView2 = setImage(x: width*1, y: 0, width: width, height: imageHeight, imageType: .image2)
-        let imageView3 = setImage(x: width*2, y: 0, width: width, height: imageHeight, imageType: .image3)
-        let imageView4 = setImage(x: width*3, y: 0, width: width, height: imageHeight, imageType: .image4)
-        let imageView5 = setImage(x: width*4, y: 0, width: width, height: imageHeight, imageType: .image5)
+        let imageView1 = setImage(x: width*0, y: 0, width: width, height: imageHeight, imageType: .firstPageImage)
+        let imageView2 = setImage(x: width*1, y: 0, width: width, height: imageHeight, imageType: .secondPageImage)
+        let imageView3 = setImage(x: width*2, y: 0, width: width, height: imageHeight, imageType: .thirdPageImage)
+        let imageView4 = setImage(x: width*3, y: 0, width: width, height: imageHeight, imageType: .fourthPageImage)
+        let imageView5 = setImage(x: width*4, y: 0, width: width, height: imageHeight, imageType: .fifthPageImage)
         scrollView.addSubview(imageView1)
         scrollView.addSubview(imageView2)
         scrollView.addSubview(imageView3)

--- a/ShoppingApplication/Controllers/HowToUseCalculationViewController.swift
+++ b/ShoppingApplication/Controllers/HowToUseCalculationViewController.swift
@@ -30,11 +30,11 @@ final class HowToUseCalculationViewController: UIViewController {
     }
     private var scrollView: UIScrollView!
     private var pageControl: UIPageControl!
-    private var button1: UIButton!
-    private var button2: UIButton!
-    private var button3: UIButton!
-    private var button4: UIButton!
-    private var button5: UIButton!
+    private var firstPageNextButton: UIButton!
+    private var secondPageNextButton: UIButton!
+    private var thirdPageNextButton: UIButton!
+    private var fourthPageNextButton: UIButton!
+    private var fifthPageCloseButton: UIButton!
     private var width: CGFloat { UIScreen.main.bounds.width }
     private var height: CGFloat { UIScreen.main.bounds.height }
     private let pageSize: CGFloat = 5
@@ -103,44 +103,44 @@ final class HowToUseCalculationViewController: UIViewController {
     
     private func setupButtonAction() {
         let buttonSize: CGFloat = 50
-        button1 = UIButton(frame: CGRect(x: width*1 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button1, buttonSize: buttonSize, buttonTextType: .next, page: 1)
-        button1.addTarget(self, action: #selector(button1DidTapped), for: .touchUpInside)
+        firstPageNextButton = UIButton(frame: CGRect(x: width*1 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: firstPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 1)
+        firstPageNextButton.addTarget(self, action: #selector(firstPageNextButtonDidTapped), for: .touchUpInside)
         
-        button2 = UIButton(frame: CGRect(x: width*2 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button2, buttonSize: buttonSize, buttonTextType: .next, page: 2)
-        button2.addTarget(self, action: #selector(button2DidTapped), for: .touchUpInside)
+        secondPageNextButton = UIButton(frame: CGRect(x: width*2 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: secondPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 2)
+        secondPageNextButton.addTarget(self, action: #selector(secondPageNextButtonDidTapped), for: .touchUpInside)
         
-        button3 = UIButton(frame: CGRect(x: width*3 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button3, buttonSize: buttonSize, buttonTextType: .next, page: 3)
-        button3.addTarget(self, action: #selector(button3DidTapped), for: .touchUpInside)
+        thirdPageNextButton = UIButton(frame: CGRect(x: width*3 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: thirdPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 3)
+        thirdPageNextButton.addTarget(self, action: #selector(thirdPageNextButtonDidTapped), for: .touchUpInside)
         
-        button4 = UIButton(frame: CGRect(x: width*4 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button4, buttonSize: buttonSize, buttonTextType: .next, page: 4)
-        button4.addTarget(self, action: #selector(button4DidTapped), for: .touchUpInside)
+        fourthPageNextButton = UIButton(frame: CGRect(x: width*4 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: fourthPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 4)
+        fourthPageNextButton.addTarget(self, action: #selector(fourthPageNextButtonDidTapped), for: .touchUpInside)
         
-        button5 = UIButton(frame: CGRect(x: width*5 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button5, buttonSize: buttonSize, buttonTextType: .close, page: 5)
-        button5.addTarget(self, action: #selector(button5DidTapped), for: .touchUpInside)
+        fifthPageCloseButton = UIButton(frame: CGRect(x: width*5 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: fifthPageCloseButton, buttonSize: buttonSize, buttonTextType: .close, page: 5)
+        fifthPageCloseButton.addTarget(self, action: #selector(fifthPageNextButtonDidTapped), for: .touchUpInside)
     }
 
-    @objc func button1DidTapped() {
+    @objc func firstPageNextButtonDidTapped() {
         scrollToPage(page: 1)
     }
     
-    @objc func button2DidTapped() {
+    @objc func secondPageNextButtonDidTapped() {
         scrollToPage(page: 2)
     }
     
-    @objc func button3DidTapped() {
+    @objc func thirdPageNextButtonDidTapped() {
         scrollToPage(page: 3)
     }
     
-    @objc func button4DidTapped() {
+    @objc func fourthPageNextButtonDidTapped() {
         scrollToPage(page: 4)
     }
     
-    @objc func button5DidTapped() {
+    @objc func fifthPageNextButtonDidTapped() {
         dismiss(animated: true)
     }
     

--- a/ShoppingApplication/Controllers/HowToUseToBuyListViewController.swift
+++ b/ShoppingApplication/Controllers/HowToUseToBuyListViewController.swift
@@ -3,18 +3,18 @@ import UIKit
 
 final class HowToUseToBuyListViewController: UIViewController {
     private enum ImageType {
-        case image1
-        case image2
-        case image3
-        case image4
-        case image5
+        case firstPageImage
+        case secondPageImage
+        case thirdPageImage
+        case fourthPageImage
+        case fifthPageImage
         var name: String {
             switch self {
-            case .image1: return "HowToUseToBuyListImage1"
-            case .image2: return "HowToUseToBuyListImage2"
-            case .image3: return "HowToUseToBuyListImage3"
-            case .image4: return "HowToUseToBuyListImage4"
-            case .image5: return "HowToUseToBuyListImage5"
+            case .firstPageImage: return "HowToUseToBuyListImage1"
+            case .secondPageImage: return "HowToUseToBuyListImage2"
+            case .thirdPageImage: return "HowToUseToBuyListImage3"
+            case .fourthPageImage: return "HowToUseToBuyListImage4"
+            case .fifthPageImage: return "HowToUseToBuyListImage5"
             }
         }
     }
@@ -72,11 +72,11 @@ final class HowToUseToBuyListViewController: UIViewController {
         } else {
             imageHeight = height
         }
-        let imageView1 = setImage(x: width*0, y: 0, width: width, height: imageHeight, imageType: .image1)
-        let imageView2 = setImage(x: width*1, y: 0, width: width, height: imageHeight, imageType: .image2)
-        let imageView3 = setImage(x: width*2, y: 0, width: width, height: imageHeight, imageType: .image3)
-        let imageView4 = setImage(x: width*3, y: 0, width: width, height: imageHeight, imageType: .image4)
-        let imageView5 = setImage(x: width*4, y: 0, width: width, height: imageHeight, imageType: .image5)
+        let imageView1 = setImage(x: width*0, y: 0, width: width, height: imageHeight, imageType: .firstPageImage)
+        let imageView2 = setImage(x: width*1, y: 0, width: width, height: imageHeight, imageType: .secondPageImage)
+        let imageView3 = setImage(x: width*2, y: 0, width: width, height: imageHeight, imageType: .thirdPageImage)
+        let imageView4 = setImage(x: width*3, y: 0, width: width, height: imageHeight, imageType: .fifthPageImage)
+        let imageView5 = setImage(x: width*4, y: 0, width: width, height: imageHeight, imageType: .fifthPageImage)
         scrollView.addSubview(imageView1)
         scrollView.addSubview(imageView2)
         scrollView.addSubview(imageView3)

--- a/ShoppingApplication/Controllers/HowToUseToBuyListViewController.swift
+++ b/ShoppingApplication/Controllers/HowToUseToBuyListViewController.swift
@@ -30,11 +30,11 @@ final class HowToUseToBuyListViewController: UIViewController {
     }
     private var scrollView: UIScrollView!
     private var pageControl: UIPageControl!
-    private var button1: UIButton!
-    private var button2: UIButton!
-    private var button3: UIButton!
-    private var button4: UIButton!
-    private var button5: UIButton!
+    private var firstPageNextButton: UIButton!
+    private var secondPageNextButton: UIButton!
+    private var thirdPageNextButton: UIButton!
+    private var fourthPageNextButton: UIButton!
+    private var fifthPageCloseButton: UIButton!
     private var width: CGFloat { UIScreen.main.bounds.width }
     private var height: CGFloat { UIScreen.main.bounds.height }
     private let pageSize: CGFloat = 5
@@ -103,44 +103,44 @@ final class HowToUseToBuyListViewController: UIViewController {
     
     private func setupButtonAction() {
         let buttonSize: CGFloat = 50
-        button1 = UIButton(frame: CGRect(x: width*1 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button1, buttonSize: buttonSize, buttonTextType: .next, page: 1)
-        button1.addTarget(self, action: #selector(button1DidTapped), for: .touchUpInside)
+        firstPageNextButton = UIButton(frame: CGRect(x: width*1 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: firstPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 1)
+        firstPageNextButton.addTarget(self, action: #selector(firstPageNextButtonDidTapped), for: .touchUpInside)
         
-        button2 = UIButton(frame: CGRect(x: width*2 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button2, buttonSize: buttonSize, buttonTextType: .next, page: 2)
-        button2.addTarget(self, action: #selector(button2DidTapped), for: .touchUpInside)
+        secondPageNextButton = UIButton(frame: CGRect(x: width*2 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: secondPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 2)
+        secondPageNextButton.addTarget(self, action: #selector(secondPageNextButtonDidTapped), for: .touchUpInside)
         
-        button3 = UIButton(frame: CGRect(x: width*3 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button3, buttonSize: buttonSize, buttonTextType: .next, page: 3)
-        button3.addTarget(self, action: #selector(button3DidTapped), for: .touchUpInside)
+        thirdPageNextButton = UIButton(frame: CGRect(x: width*3 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: thirdPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 3)
+        thirdPageNextButton.addTarget(self, action: #selector(thirdPageNextButtonDidTapped), for: .touchUpInside)
         
-        button4 = UIButton(frame: CGRect(x: width*4 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button4, buttonSize: buttonSize, buttonTextType: .next, page: 4)
-        button4.addTarget(self, action: #selector(button4DidTapped), for: .touchUpInside)
+        fourthPageNextButton = UIButton(frame: CGRect(x: width*4 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: fourthPageNextButton, buttonSize: buttonSize, buttonTextType: .next, page: 4)
+        fourthPageNextButton.addTarget(self, action: #selector(fourthPageNextButtonDidTapped), for: .touchUpInside)
         
-        button5 = UIButton(frame: CGRect(x: width*5 - 80, y: 30, width: buttonSize, height: buttonSize))
-        setupButton(button: button5, buttonSize: buttonSize, buttonTextType: .close, page: 5)
-        button5.addTarget(self, action: #selector(button5DidTapped), for: .touchUpInside)
+        fifthPageCloseButton = UIButton(frame: CGRect(x: width*5 - 80, y: 30, width: buttonSize, height: buttonSize))
+        setupButton(button: fifthPageCloseButton, buttonSize: buttonSize, buttonTextType: .close, page: 5)
+        fifthPageCloseButton.addTarget(self, action: #selector(fifthPageNextButtonDidTapped), for: .touchUpInside)
     }
 
-    @objc func button1DidTapped() {
+    @objc func firstPageNextButtonDidTapped() {
         scrollToPage(page: 1)
     }
     
-    @objc func button2DidTapped() {
+    @objc func secondPageNextButtonDidTapped() {
         scrollToPage(page: 2)
     }
     
-    @objc func button3DidTapped() {
+    @objc func thirdPageNextButtonDidTapped() {
         scrollToPage(page: 3)
     }
     
-    @objc func button4DidTapped() {
+    @objc func fourthPageNextButtonDidTapped() {
         scrollToPage(page: 4)
     }
     
-    @objc func button5DidTapped() {
+    @objc func fifthPageNextButtonDidTapped() {
         dismiss(animated: true)
     }
     


### PR DESCRIPTION
[修正前]
button1, button2, button3 ...など、一見どのボタンなのかわからない命名にしていました。

[修正後]
firstPageNextButtonなど、1枚目の次へ行くためのボタンなんだとわかるように命名を変更しました。

[関連issue]
#8