### PR TITLE
アラートで同じ文字列を共通化しました

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,44 +1,44 @@
 PODS:
   - Alamofire (5.4.1)
-  - Google-Mobile-Ads-SDK (7.69.0):
+  - Google-Mobile-Ads-SDK (8.2.0.1):
     - GoogleAppMeasurement (~> 7.0)
-    - GoogleUserMessagingPlatform (~> 1.1)
-  - GoogleAppMeasurement (7.3.0):
+    - GoogleUserMessagingPlatform (>= 1.1)
+  - GoogleAppMeasurement (7.8.1):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
-    - nanopb (~> 2.30906.0)
-  - GoogleMaps (4.1.0):
-    - GoogleMaps/Maps (= 4.1.0)
-  - GoogleMaps/Base (4.1.0)
-  - GoogleMaps/Maps (4.1.0):
+    - nanopb (~> 2.30907.0)
+  - GoogleMaps (4.2.0):
+    - GoogleMaps/Maps (= 4.2.0)
+  - GoogleMaps/Base (4.2.0)
+  - GoogleMaps/Maps (4.2.0):
     - GoogleMaps/Base
-  - GooglePlaces (4.1.0):
-    - GoogleMaps/Base (= 4.1.0)
-  - GoogleUserMessagingPlatform (1.4.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.1.1):
+  - GooglePlaces (4.2.0):
+    - GoogleMaps/Base (= 4.2.0)
+  - GoogleUserMessagingPlatform (2.0.0)
+  - GoogleUtilities/AppDelegateSwizzler (7.3.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.1.1):
+  - GoogleUtilities/Environment (7.3.1):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (7.1.1):
+  - GoogleUtilities/Logger (7.3.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.1.1):
+  - GoogleUtilities/MethodSwizzler (7.3.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.1.1):
+  - GoogleUtilities/Network (7.3.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.1.1)"
-  - GoogleUtilities/Reachability (7.1.1):
+  - "GoogleUtilities/NSData+zlib (7.3.1)"
+  - GoogleUtilities/Reachability (7.3.1):
     - GoogleUtilities/Logger
-  - nanopb (2.30906.0):
-    - nanopb/decode (= 2.30906.0)
-    - nanopb/encode (= 2.30906.0)
-  - nanopb/decode (2.30906.0)
-  - nanopb/encode (2.30906.0)
+  - nanopb (2.30907.0):
+    - nanopb/decode (= 2.30907.0)
+    - nanopb/encode (= 2.30907.0)
+  - nanopb/decode (2.30907.0)
+  - nanopb/encode (2.30907.0)
   - PromisesObjC (1.2.12)
   - Realm (5.1.0):
     - Realm/Headers (= 5.1.0)
@@ -69,13 +69,13 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 2291f7d21ca607c491dd17642e5d40fdcda0e65c
-  Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
-  GoogleAppMeasurement: 8d3c0aeede16ab7764144b5a4ca8e1d4323841b7
-  GoogleMaps: 008e2c80e38605b56b560e8deb73d4194ff30bef
-  GooglePlaces: a058b776259c13e1323c9ff135549cb1b13ad8e7
-  GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
-  GoogleUtilities: 3dc4ff0d5e4840e2fa8eef0889620e8c33d4218c
-  nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
+  Google-Mobile-Ads-SDK: b48fb7dc45b2e442a217dd96875586fda7d5e553
+  GoogleAppMeasurement: 50a254ee92c1b94fbe2abea7e3da35e4c6dedce0
+  GoogleMaps: eb03e327edfd70b06de1e6e321653f73712df7ad
+  GooglePlaces: 196a9dd88580dcb3f3df46f415057703d0d2a310
+  GoogleUserMessagingPlatform: ab890ce5f6620f293a21b6bdd82e416a2c73aeca
+  GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
+  nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Realm: bdea546851e37b4cf0a2400cef115c7c26fda488
   RealmSwift: 70945aa168db93b215c460e9c8ef680261aa28af

--- a/ShoppingApplication/Controllers/CalculationViewController.swift
+++ b/ShoppingApplication/Controllers/CalculationViewController.swift
@@ -141,12 +141,12 @@ final class CalculationViewController: UIViewController {
             let alert = UIAlertController(title: "全て消去しますか？",
                                           message: "消去したものは元に戻せません。",
                                           preferredStyle: .alert)
-            let defaultAction = UIAlertAction(title: "消去する", style: .default) { (_) in
+            let defaultAction = UIAlertAction(title: .delete, style: .default) { (_) in
                 CalculationRealmRepository.shared.delete(self.calculations)
                 self.collectionView.reloadData()
                 self.clearLabel()
             }
-            let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel) { (_) in
+            let cancelAction = UIAlertAction(title: .cancel, style: .cancel) { (_) in
                 self.dismiss(animated: true, completion: nil)
             }
             alert.addAction(defaultAction)
@@ -206,7 +206,7 @@ final class CalculationViewController: UIViewController {
             let alert = UIAlertController(title: "エラー",
                                           message: "金額が大きすぎます",
                                           preferredStyle: .actionSheet)
-            let defaultAction = UIAlertAction(title: "閉じる", style: .default) { (_) in
+            let defaultAction = UIAlertAction(title: .close, style: .default) { (_) in
                 self.clearLabel()
             }
             alert.addAction(defaultAction)
@@ -407,7 +407,7 @@ extension CalculationViewController: ShoppingListCollectionViewCellDelegate {
     
     func deleteButtonDidTapped(_ tag: Int) {
         let alert = UIAlertController(title: "これを消去しますか？", message: "消去したものは元に戻せません。", preferredStyle: .alert)
-        let alertDefaultAction = UIAlertAction(title: "消去する", style: .default) { (_) in
+        let alertDefaultAction = UIAlertAction(title: .delete, style: .destructive) { (_) in
             CalculationRealmRepository.shared.update {
                 self.calculations[tag].isCalculationDeleted = true
             }
@@ -415,7 +415,7 @@ extension CalculationViewController: ShoppingListCollectionViewCellDelegate {
             CalculationRealmRepository.shared.delete(deletedObjects)
             self.collectionView.reloadData()
         }
-        let alertCancelAction = UIAlertAction(title: "キャンセル", style: .cancel) { (_) in
+        let alertCancelAction = UIAlertAction(title: .cancel, style: .cancel) { (_) in
             self.dismiss(animated: true, completion: nil)
         }
         alert.addAction(alertDefaultAction)

--- a/ShoppingApplication/Controllers/CalculationViewController.swift
+++ b/ShoppingApplication/Controllers/CalculationViewController.swift
@@ -138,8 +138,8 @@ final class CalculationViewController: UIViewController {
     
     @IBAction func clearAllButtonDidTapped(_ sender: Any) {
         if calculations.count != 0 {
-            let alert = UIAlertController(title: "全て消去しますか？",
-                                          message: "消去したものは元に戻せません。",
+            let alert = UIAlertController(title: .deleteAll,
+                                          message: .deleteAttention,
                                           preferredStyle: .alert)
             let defaultAction = UIAlertAction(title: .delete, style: .default) { (_) in
                 CalculationRealmRepository.shared.delete(self.calculations)
@@ -203,8 +203,8 @@ final class CalculationViewController: UIViewController {
             priceLabel.font = .systemFont(ofSize: 20)
         }
         if priceMaxCount > 6 {
-            let alert = UIAlertController(title: "エラー",
-                                          message: "金額が大きすぎます",
+            let alert = UIAlertController(title: .error,
+                                          message: .priceTooLarge,
                                           preferredStyle: .actionSheet)
             let defaultAction = UIAlertAction(title: .close, style: .default) { (_) in
                 self.clearLabel()
@@ -406,7 +406,7 @@ extension CalculationViewController: UIPickerViewDataSource {
 extension CalculationViewController: ShoppingListCollectionViewCellDelegate {
     
     func deleteButtonDidTapped(_ tag: Int) {
-        let alert = UIAlertController(title: "これを消去しますか？", message: "消去したものは元に戻せません。", preferredStyle: .alert)
+        let alert = UIAlertController(title: .deleteList, message: .deleteAttention, preferredStyle: .alert)
         let alertDefaultAction = UIAlertAction(title: .delete, style: .destructive) { (_) in
             CalculationRealmRepository.shared.update {
                 self.calculations[tag].isCalculationDeleted = true

--- a/ShoppingApplication/Controllers/MapViewController.swift
+++ b/ShoppingApplication/Controllers/MapViewController.swift
@@ -100,7 +100,7 @@ extension MapViewController: UISearchBarDelegate {
                 let alert = UIAlertController(title: "周辺で探した結果",
                                               message: "検索結果は0です",
                                               preferredStyle: .alert)
-                let cancelAction = UIAlertAction(title: "閉じる", style: .cancel)
+                let cancelAction = UIAlertAction(title: .close, style: .cancel)
                 alert.addAction(cancelAction)
                 self.present(alert, animated: true)
             }

--- a/ShoppingApplication/Controllers/MapViewController.swift
+++ b/ShoppingApplication/Controllers/MapViewController.swift
@@ -97,8 +97,8 @@ extension MapViewController: UISearchBarDelegate {
                     marker.map = self.mapView
                 }
             } else {
-                let alert = UIAlertController(title: "周辺で探した結果",
-                                              message: "検索結果は0です",
+                let alert = UIAlertController(title: .resultFoundInSurrounding,
+                                              message: .searchResultIsZero,
                                               preferredStyle: .alert)
                 let cancelAction = UIAlertAction(title: .close, style: .cancel)
                 alert.addAction(cancelAction)

--- a/ShoppingApplication/Controllers/ToBuyListViewController.swift
+++ b/ShoppingApplication/Controllers/ToBuyListViewController.swift
@@ -170,15 +170,15 @@ final class ToBuyListViewController: UIViewController {
     }
     
     private func showAlert() {
-        let alert = UIAlertController(title: "チェックしたメモを\n消去しますか？",
-                                      message: "消去したものは元に戻せません。",
+        let alert = UIAlertController(title: .deleteMemo,
+                                      message: .deleteAttention,
                                       preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: "メモを消去する", style: .destructive) { [unowned self] (_) in
+        let defaultAction = UIAlertAction(title: .delete, style: .destructive) { [unowned self] (_) in
             let checkedObjects = ToBuyListRealmRepository.shared.filter("isButtonChecked == true")
             ToBuyListRealmRepository.shared.delete(checkedObjects)
             tableView.reloadData()
         }
-        let cancelAction = UIAlertAction(title: .cancel, style: .cancel) { [unowned self] (_) in
+        let cancelAction = UIAlertAction(title: .cancel, style: .cancel) { [unowned self] (_) in 
             dismiss(animated: true, completion: nil)
         }
         alert.addAction(defaultAction)

--- a/ShoppingApplication/Controllers/ToBuyListViewController.swift
+++ b/ShoppingApplication/Controllers/ToBuyListViewController.swift
@@ -178,7 +178,7 @@ final class ToBuyListViewController: UIViewController {
             ToBuyListRealmRepository.shared.delete(checkedObjects)
             tableView.reloadData()
         }
-        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel) { [unowned self] (_) in
+        let cancelAction = UIAlertAction(title: .cancel, style: .cancel) { [unowned self] (_) in
             dismiss(animated: true, completion: nil)
         }
         alert.addAction(defaultAction)

--- a/ShoppingApplication/Extension/String+Extension.swift
+++ b/ShoppingApplication/Extension/String+Extension.swift
@@ -18,4 +18,16 @@ extension String {
         return numberFormatter.string(from: NSNumber(integerLiteral: number))!
     }
     
+    static var delete: String {
+        return "消去する"
+    }
+    
+    static var cancel: String {
+        return "キャンセル"
+    }
+    
+    static var close: String {
+        return "閉じる"
+    }
+    
 }

--- a/ShoppingApplication/Extension/String+Extension.swift
+++ b/ShoppingApplication/Extension/String+Extension.swift
@@ -19,7 +19,23 @@ extension String {
     }
     
     static var delete: String {
-        return "消去する"
+        return "消去"
+    }
+    
+    static var deleteAll: String {
+        return "全て消去する"
+    }
+    
+    static var deleteMemo: String {
+        return "チェックしたメモを\n消去しますか？"
+    }
+    
+    static var deleteList: String {
+        return "これを消去しますか？"
+    }
+    
+    static var deleteAttention: String {
+        return "消去したものは元に戻せません。"
     }
     
     static var cancel: String {
@@ -28,6 +44,22 @@ extension String {
     
     static var close: String {
         return "閉じる"
+    }
+    
+    static var error: String {
+        return "エラー"
+    }
+    
+    static var priceTooLarge: String {
+        return "金額が大きすぎます"
+    }
+    
+    static var resultFoundInSurrounding: String {
+        return "周辺で探した結果"
+    }
+    
+    static var searchResultIsZero: String {
+        return "検索結果は0です"
     }
     
 }


### PR DESCRIPTION
[修正前]
"閉じる", "キャンセル", "消去する"など、複数のファイルで同じ文字列を書いていました。

[修正後]
`extension String`にそれぞれ変数を用意し、共通化させました。

[関連issue]
#10 